### PR TITLE
allow custom ResolverConfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 //! }
 //! ```
 
-use hickory_resolver::config::ResolverConfig;
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_resolver::Resolver;
 use hickory_resolver::TokioResolver;
@@ -54,7 +53,9 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 
 // Re-export ResolverOpts as part of the public API.
+pub use hickory_resolver::config;
 pub use hickory_resolver::config::ResolverOpts;
+pub use hickory_resolver::config::ResolverConfig;
 
 /// HickoryResolver implements reqwest [`Resolve`] so that we can use it as reqwest's DNS resolver.
 #[derive(Debug, Default, Clone)]
@@ -64,6 +65,7 @@ pub struct HickoryResolver {
     /// construction of the resolver.
     state: Arc<OnceLock<TokioResolver>>,
 
+    conf: Option<ResolverConfig>,
     opts: Option<ResolverOpts>,
     rng: Option<rand::rngs::SmallRng>,
 }
@@ -72,6 +74,12 @@ impl HickoryResolver {
     /// Configure the resolver with input options.
     pub fn with_options(mut self, opts: ResolverOpts) -> Self {
         self.opts = Some(opts);
+        self
+    }
+
+    /// Configure the resolver with custom Config.
+    pub fn with_config(mut self, conf: ResolverConfig) -> Self {
+        self.conf = Some(conf);
         self
     }
 
@@ -94,10 +102,18 @@ impl HickoryResolver {
     fn init_resolver(&self) -> TokioResolver {
         let mut builder =
             Resolver::builder(TokioConnectionProvider::default()).unwrap_or_else(|_| {
-                Resolver::builder_with_config(
-                    ResolverConfig::default(),
-                    TokioConnectionProvider::default(),
-                )
+                match &self.conf {
+                    None =>
+                        Resolver::builder_with_config(
+                            ResolverConfig::default(),
+                            TokioConnectionProvider::default()
+                        ),
+                    Some(cfg) =>
+                        Resolver::builder_with_config(
+                            cfg.clone(),
+                            TokioConnectionProvider::default(),
+                        )
+                }               
             });
 
         if let Some(mut opt) = self.opts.clone() {


### PR DESCRIPTION
This allows to use something like:

```
/// Global shared hickory resolver.
static GLOBAL_HICKORY_RESOLVER: LazyLock<Arc<HickoryResolver>> = LazyLock::new(|| {

    //let mut conf = trust_dns_resolver::config::ResolverConfig::google();
    let conf = reqwest_hickory_resolver::ResolverConfig::google();

    let mut opts: reqwest_hickory_resolver::ResolverOpts = reqwest_hickory_resolver::ResolverOpts::default();
    // Only query for the ipv4 address.
    opts.ip_strategy = reqwest_hickory_resolver::config::LookupIpStrategy::Ipv4Only;

    // Use larger cache size for better performance.
    opts.cache_size = 1024;
    // Positive TTL is set to 5 minutes.
    opts.positive_min_ttl = Some(Duration::from_secs(300));
    // Negative TTL is set to 1 minute.
    opts.negative_min_ttl = Some(Duration::from_secs(60));

    Arc::new(
        HickoryResolver::default()
            // Always shuffle the DNS results for better performance.
            .with_shuffle(true)
            //.with_config(conf)
            .with_options(opts),
    )
});


 let result = reqwest::Client::builder()
        .use_rustls_tls()

        // Custom DNS Resolver
        .dns_resolver(GLOBAL_HICKORY_RESOLVER.clone())

        .timeout(Duration::from_secs(5))
        .build()?
```